### PR TITLE
Fixed deprecated iterator function call.

### DIFF
--- a/web/routers/application_router.ex
+++ b/web/routers/application_router.ex
@@ -29,7 +29,7 @@ defmodule ApplicationRouter do
     conn = conn.resp_content_type("text/event-stream")
     conn = conn.send_chunked(200)
 
-    iterator = File.iterator!("#{conn.params[:story_name]}.txt")
+    iterator = File.stream!("#{conn.params[:story_name]}.txt")
 
     Enum.each iterator, fn(line) ->
       { :ok, conn } = conn.chunk "data: #{line}\n"


### PR DESCRIPTION
It seems that #iterator! was deprecated. Invoking #stream! does the trick.

Old error:

```
=ERROR REPORT==== 25-Oct-2013::18:06:22 ===
      Conn: GET /play/snow-white
    Reason: (UndefinedFunctionError) undefined function: File.iterator/1
```
